### PR TITLE
reflect module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+output.json
+node_modules

--- a/README.md
+++ b/README.md
@@ -7,3 +7,24 @@ This repo is for exploring runtime reflection in TypeScript and includes use cas
 * [reflec-ts](https://github.com/pcan/reflec-ts) - Paused fork/wrapper for TypeScript compiler that adds Java/C# style reflection API.
 * [tst-reflect](https://github.com/Hookyns/tst-reflect) - Possible usable(!) TypeScript compiler extension that also generates intermediate representation and C# style API.
 * [ts-json-schema-generator](https://github.com/vega/ts-json-schema-generator) - Not reflection, but similar idea of parsing TS symbols to generate JSON schema.
+
+## Schema Gen
+
+### Running the main.ts file
+
+```bash
+deno run --allow-read=. --allow-write=. ./gen/main.ts ./examples/test.ts
+```
+
+This will run the demo program.
+
+### Bundling for Web
+
+Run:
+```bash
+node build.js
+```
+
+This will build the web target to `./build/`
+
+### Running demo in Browser

--- a/README.md
+++ b/README.md
@@ -28,3 +28,10 @@ node build.js
 This will build the web target to `./build/`
 
 ### Running demo in Browser
+
+```bash
+cd build
+python3 -m http.server
+```
+
+Then open http://localhost:8000.

--- a/build.js
+++ b/build.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+
+const esbuild = require('esbuild');
+
+//
+// Helpers
+//
+
+const OS_CopyFile = (from, to) => {
+    return fs.copyFileSync(from, to);
+};
+
+//
+// Plugins
+//
+
+const nodeModules = new RegExp(/^(?:.*[\\\/])?node_modules(?:[\\\/].*)?$/);
+
+const dirnamePlugin = {
+  name: "dirname",
+  setup(build) {
+    build.onLoad({ filter: /.*/ }, ({ path: filePath }) => {
+      if (!filePath.match(nodeModules)) {
+        let contents = fs.readFileSync(filePath, "utf8");
+        const loader = path.extname(filePath).substring(1);
+
+        const filename = filePath.replaceAll('\\', '/');
+        const dirname = path.dirname(filename);
+        
+        contents = contents
+          .replaceAll("__dirname", `"${dirname}"`)
+          .replaceAll("__filename", `"${filename}"`);
+
+        return {
+          contents,
+          loader,
+        };
+      }
+    });
+  },
+};
+
+//
+// Run
+//
+
+(async () => {
+
+  let entry = path.resolve(__dirname, './examples/demo/demo.ts')
+  if (process.argv[2])
+  {
+    entry = path.resolve(process.cwd(), process.argv[2]);
+  }
+
+  await esbuild.build({
+    entryPoints: [entry],
+    bundle: true,
+    outdir: 'build',
+    target: ['es2018'],
+    plugins: [dirnamePlugin],
+  });
+
+  OS_CopyFile(path.resolve(__dirname, 'output.json'), path.resolve(__dirname, 'build/schema.json'));
+  OS_CopyFile(path.resolve(__dirname, './examples/demo/index.html'), path.resolve(__dirname, 'build/index.html'));
+
+  console.log('Done!');
+})();

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -1,0 +1,30 @@
+import * as reflect from '../../gen/reflect.ts';
+
+// @Hack: polyfill for Deno __filename
+if (typeof __filename === 'undefined')
+{
+  window['__filename'] = new URL('', import.meta.url).href.slice('file:///'.length);
+}
+
+export class Entity {
+  lifeSatisfaction: number;
+};
+reflect.Type(Entity, __filename);
+
+export class Player extends Entity {
+  happinessLevel: number;
+};
+reflect.Type(Player, __filename);
+
+
+if (typeof window.fetch !== 'undefined')
+{
+    fetch('/schema.json')
+        .then((resp) => resp.json())
+        .then((json) => {
+            const schema = reflect.loadSchema(json);
+
+            const t = schema.TypeOf(Player);
+            console.log({ t });
+        });
+}

--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Demo</title>
+  </head>
+  <body>
+    <script src="./demo.js"></script>
+  </body>
+</html>

--- a/examples/test.ts
+++ b/examples/test.ts
@@ -1,5 +1,3 @@
-import * as reflect from '../gen/reflect.ts';
-
 // 1
 //export type Foo = string;
 
@@ -170,16 +168,5 @@ export type B = {
   x: number;
   y: string;
   z: boolean;
-};
-*/
-
-// 20
-/*
-class Entity {
-  lifeSatisfaction: number;
-};
-
-class Player extends Entity {
-  happinessLevel: number;
 };
 */

--- a/examples/test.ts
+++ b/examples/test.ts
@@ -20,13 +20,13 @@ export interface Point {
 */
 
 // 6
+/*
 export interface Printer {
   public label?: string;
 
   print(verbose: boolean): string;
-
-  //foo: () => void;
 }
+*/
 
 // 7
 /*
@@ -138,3 +138,8 @@ export interface Bank_Account {
   readonly balance: number;
 };
 */
+
+// 18
+export class Foo {
+}
+Foo.__fqn = '/examples/test.Foo';

--- a/examples/test.ts
+++ b/examples/test.ts
@@ -142,7 +142,44 @@ export interface Bank_Account {
 */
 
 // 18
+/*
 export class Foo {
 }
-
 reflect.ReflectType(Foo);
+*/
+
+// 19
+/*
+export type Number = number;
+
+export type Object = object;
+
+export type NumberOrString = number | string;
+
+export class MyObject {
+  foo: string;
+  bar: number;
+}
+
+export type A = {
+  x: number;
+  y: string;
+};
+
+export type B = {
+  x: number;
+  y: string;
+  z: boolean;
+};
+*/
+
+// 20
+/*
+class Entity {
+  lifeSatisfaction: number;
+};
+
+class Player extends Entity {
+  happinessLevel: number;
+};
+*/

--- a/examples/test.ts
+++ b/examples/test.ts
@@ -1,3 +1,5 @@
+import * as reflect from '../gen/reflect.ts';
+
 // 1
 //export type Foo = string;
 
@@ -142,4 +144,5 @@ export interface Bank_Account {
 // 18
 export class Foo {
 }
-Foo.__fqn = '/examples/test.Foo';
+
+reflect.ReflectType(Foo);

--- a/gen/.gitignore
+++ b/gen/.gitignore
@@ -1,1 +1,0 @@
-output.json

--- a/gen/ast.ts
+++ b/gen/ast.ts
@@ -331,11 +331,21 @@ const resolveImport = (currentFilePath, importPath) => {
   return path.resolve(path.dirname(currentFilePath), importPath);
 };
 
+const getCommentString = (fullText, node) => {
+  if (node) {
+    const ranges = ts.getLeadingCommentRanges(fullText, node.getFullStart());
+    return (ranges || []).map((r) => fullText.slice(r.pos, r.end)).join('\n');
+  }
+  return '';
+};
+
 export const inflate = (node, context) => {
   const { schema, filePath } = context;
 
   const kind = getKind(node);
   const name = getName(node);
+
+  //const comment = context.rootNode ? getCommentString(context.rootNode.getFullText(), node) : '';
 
   print("[inflate]", { kind, name });
 
@@ -363,10 +373,12 @@ export const inflate = (node, context) => {
     case 'TypeLiteral':
     case 'ClassDeclaration':
     case 'InterfaceDeclaration': {
-      print("HERE!");
-
-      // @Incomplete: parse `extends` keyword
-      const result = makeType({ Name: name, Kind: 'struct', PkgPath: filePath });
+      const result = makeType({
+        Name: name,
+        Kind: 'struct',
+        PkgPath: filePath,
+        //Comment: getCommentString(context.rootNode.getFullText(), node),
+      });
 
       const props = getProperties(node);
       props.forEach((prop) => {

--- a/gen/main.ts
+++ b/gen/main.ts
@@ -88,14 +88,16 @@ const main = async () => {
     const json = ast.toJSON(schema);
     Deno.writeTextFileSync("output.json", json);
 
-    const testSchema = reflect.loadSchema(json);
-    const fooSchema = testSchema.GetTypeByName('Foo');
+    const s = reflect.loadSchema(json);
+    const number = s.GetTypeByName('Number');
+    const numberOrString = s.GetTypeByName('NumberOrString');
 
-    const fooType = testSchema.TypeOf(Foo);
+    //assert(s.AssignableTo(number, numberOrString), "Number is not AssignableTo NumberOrString");
 
-    console.log({ fooSchema, fooType });
-
-    console.log(testSchema.AssignableTo(fooSchema, fooType));
+    const obj = s.GetTypeByName('Object');
+    const myObj = s.GetTypeByName('MyObject');
+    console.log("----------");
+    console.log(s.AssignableTo(myObj, obj), "MyObject should be AssignableTo Object");
   }
 };
 

--- a/gen/main.ts
+++ b/gen/main.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { expandGlobSync } from "https://deno.land/std@0.121.0/fs/expand_glob.ts";
 
 import * as ast from './ast.ts';
+import * as reflect from './reflect.ts';
 
 import { Foo } from '../examples/test.ts';
 
@@ -87,10 +88,12 @@ const main = async () => {
     const json = ast.toJSON(schema);
     Deno.writeTextFileSync("output.json", json);
 
-    const testSchema = ast.loadSchema(json);
+    const testSchema = reflect.loadSchema(json);
     const fooSchema = testSchema.GetTypeByName('Foo');
 
     const fooType = testSchema.TypeOf(Foo);
+
+    console.log({ fooSchema, fooType });
 
     console.log(testSchema.AssignableTo(fooSchema, fooType));
   }

--- a/gen/main.ts
+++ b/gen/main.ts
@@ -3,6 +3,11 @@
 // > deno run --allow-read=.. --allow-write=.. .\main.ts ..\examples\test.ts
 //
 
+//
+// Bundle for web with:
+// > yarn run esbuild --bundle .\examples\test.ts --outdir=build --target=es2018 --sourcemap
+//
+
 import ts from "npm:typescript@5.0.4";
 import path from 'node:path';
 import { expandGlobSync } from "https://deno.land/std@0.121.0/fs/expand_glob.ts";
@@ -10,13 +15,7 @@ import { expandGlobSync } from "https://deno.land/std@0.121.0/fs/expand_glob.ts"
 import * as ast from './ast.ts';
 import * as reflect from './reflect.ts';
 
-import { Foo } from '../examples/test.ts';
-
-/*
-class Foo {
-}
-ast.ReflectType(Foo);
-*/
+import { Player } from '../examples/test.ts';
 
 //
 // Helpers
@@ -89,15 +88,10 @@ const main = async () => {
     Deno.writeTextFileSync("output.json", json);
 
     const s = reflect.loadSchema(json);
-    const number = s.GetTypeByName('Number');
-    const numberOrString = s.GetTypeByName('NumberOrString');
+    console.log(s)
 
-    //assert(s.AssignableTo(number, numberOrString), "Number is not AssignableTo NumberOrString");
-
-    const obj = s.GetTypeByName('Object');
-    const myObj = s.GetTypeByName('MyObject');
-    console.log("----------");
-    console.log(s.AssignableTo(myObj, obj), "MyObject should be AssignableTo Object");
+    const t = s.TypeOf(Player);
+    console.log({ t })
   }
 };
 

--- a/gen/main.ts
+++ b/gen/main.ts
@@ -9,6 +9,14 @@ import { expandGlobSync } from "https://deno.land/std@0.121.0/fs/expand_glob.ts"
 
 import * as ast from './ast.ts';
 
+import { Foo } from '../examples/test.ts';
+
+/*
+class Foo {
+}
+ast.ReflectType(Foo);
+*/
+
 //
 // Helpers
 //
@@ -76,7 +84,15 @@ const main = async () => {
     console.log("schema.Types =", schema.Types);
     console.log("schema.Exports =", schema.Exports().map((it) => it.Name));
 
-    Deno.writeTextFileSync("output.json", ast.toJSON(schema));
+    const json = ast.toJSON(schema);
+    Deno.writeTextFileSync("output.json", json);
+
+    const testSchema = ast.loadSchema(json);
+    const fooSchema = testSchema.GetTypeByName('Foo');
+
+    const fooType = testSchema.TypeOf(Foo);
+
+    console.log(testSchema.AssignableTo(fooSchema, fooType));
   }
 };
 

--- a/gen/reflect.ts
+++ b/gen/reflect.ts
@@ -1,0 +1,51 @@
+import { makeSchema, traverse, toFullyQualifiedName } from './shared.ts';
+
+export const loadSchema = (schema) => {
+  if (typeof schema === 'string')
+  {
+    try {
+      schema = JSON.parse(schema);
+    } catch(err) {
+    }
+  }
+
+  const result = makeSchema({ ...schema });
+
+  traverse(result, (node, { parent, key, index }) => {
+    if (node.$type) {
+      const type = result.Types[node.$type];
+      if (index >= 0) {
+        parent[key][index] = type;
+      } else {
+        parent[key] = type;
+      }
+    }
+  });
+
+  return result;
+};
+
+export const ReflectType = (clazz, fqn = null) => {
+  if (!fqn) {
+    const message = new Error().stack;
+    let file = message.split('at ')[2];
+
+    //
+    // NOTE(nick): in Deno this looks like:
+    // C:/dev/_projects/progrium/reflect-ts/gen/main.ts:14:5
+    //
+    if (file.startsWith('file:///')) file = file.slice('file:///'.length);
+
+    const lastSlash = file.lastIndexOf('/');
+    if (lastSlash >= 0) {
+      const lastColon = file.indexOf(':', lastSlash + 1);
+      if (lastColon >= 0) {
+        file = file.slice(0, lastColon);
+      }
+    }
+
+    fqn = toFullyQualifiedName({ Name: clazz.name, PkgPath: file });
+  }
+
+  clazz.__fqn = fqn;
+};

--- a/gen/reflect.ts
+++ b/gen/reflect.ts
@@ -25,27 +25,29 @@ export const loadSchema = (schema) => {
   return result;
 };
 
-export const ReflectType = (clazz, fqn = null) => {
-  if (!fqn) {
+export const Type = (clazz, file = null) => {
+  if (!file) {
     const message = new Error().stack;
-    let file = message.split('at ')[2];
-
-    //
-    // NOTE(nick): in Deno this looks like:
-    // C:/dev/_projects/progrium/reflect-ts/gen/main.ts:14:5
-    //
-    if (file.startsWith('file:///')) file = file.slice('file:///'.length);
-
-    const lastSlash = file.lastIndexOf('/');
-    if (lastSlash >= 0) {
-      const lastColon = file.indexOf(':', lastSlash + 1);
-      if (lastColon >= 0) {
-        file = file.slice(0, lastColon);
-      }
-    }
-
-    fqn = toFullyQualifiedName({ Name: clazz.name, PkgPath: file });
+    file = message.split('at ')[2];
   }
 
+  //
+  // NOTE(nick): in Deno this looks like:
+  // C:/dev/_projects/progrium/reflect-ts/gen/main.ts:14:5
+  //
+  if (file.includes('file:///')) {
+    const index = file.indexOf('file:///');
+    file = file.slice(index + 'file:///'.length);
+  }
+
+  const lastSlash = file.lastIndexOf('/');
+  if (lastSlash >= 0) {
+    const lastColon = file.indexOf(':', lastSlash + 1);
+    if (lastColon >= 0) {
+      file = file.slice(0, lastColon);
+    }
+  }
+
+  const fqn = toFullyQualifiedName({ Name: clazz.name, PkgPath: file });
   clazz.__fqn = fqn;
 };

--- a/gen/shared.ts
+++ b/gen/shared.ts
@@ -1,4 +1,20 @@
-import path from 'node:path';
+//
+// NOTE(nick): stub for path extname because deno can't bundle the node:path module
+//
+const path__extname = (path) => {
+  const slashIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+
+  if (slashIndex >= 0)
+  {
+    const dotIndex = path.lastIndexOf('.', slashIndex);
+    if (dotIndex >= 0 && slashIndex < dotIndex)
+    {
+      return path.slice(dotIndex, path.length);
+    }
+  }
+
+  return path;
+};
 
 export class Type {
   constructor(obj) {
@@ -145,7 +161,7 @@ export const normalizePath = (filePath) => {
 export const toFullyQualifiedName = (it) => {
   const pkgPath = normalizePath(it.PkgPath);
 
-  const ext = path.extname(pkgPath);
+  const ext = path__extname(pkgPath);
   const prefix = ext.length > 0 ? pkgPath.slice(0, pkgPath.length - ext.length) : pkgPath;
   return it.Name.startsWith(prefix) ? it.Name : `${prefix}.${it.Name}`;
 };

--- a/gen/shared.ts
+++ b/gen/shared.ts
@@ -62,6 +62,8 @@ export class Schema {
     if ((typeof x === 'object' && x !== null) || (typeof x === 'function'))
     {
       const fqn = x.prototype.__fqn || x.__fqn;
+      console.log('[TypeOf]', { fqn });
+
       if (typeof fqn === 'string')
       {
         result = this.Types[fqn] || null;

--- a/gen/shared.ts
+++ b/gen/shared.ts
@@ -1,0 +1,180 @@
+import path from 'node:path';
+
+export class Type {
+  constructor(obj) {
+    Object.assign(this, obj);
+  }
+};
+
+export class Field {
+  constructor(obj) {
+    Object.assign(this, obj);
+  }
+};
+
+export class Argument {
+  constructor(obj) {
+    Object.assign(this, obj);
+  }
+};
+
+export class Schema {
+  Types = {};
+
+  constructor(obj) {
+    Object.assign(this, obj);
+  }
+
+  Exports = () => {
+    return Object.values(this.Types).filter((it) => it.Visibility === 'exported');
+  }
+
+  All = () => {
+    return Object.values(this.Types);
+  };
+
+  GetTypesByName = (name) => {
+    return this.All().filter((it) => it.Name === name);
+  };
+
+  GetTypeByName = (name) => {
+    return this.All().find((it) => it.Name === name);
+  };
+
+  TypeOf = (x) => {
+    let result = null;
+    if ((typeof x === 'object' && x !== null) || (typeof x === 'function'))
+    {
+      const fqn = x.prototype.__fqn || x.__fqn;
+      if (typeof fqn === 'string')
+      {
+        result = this.Types[fqn] || null;
+
+        if (!result)
+        {
+            // NOTE(nick): scan for partial file match
+            let index = fqn.indexOf('/');
+            while (index >= 0)
+            {
+                const partialFqn = fqn.slice(index, fqn.length);
+                result = this.Types[partialFqn];
+                if (result)
+                {
+                    break;
+                }
+
+                index = fqn.indexOf('/', index + 1);
+            }
+        }
+      }
+    }
+    return result;
+  }
+
+  AssignableTo = (t, dest) => {
+    if (!t || !dest) return false;
+    if (t === dest) return true;
+    if (dest.Kind === 'struct') {
+      // TODO(nick): check if t fields overlap with dest fields (recursivley, if .Types)
+    }
+    return false;
+  }
+};
+
+export const makeType = (obj = {}) => new Type({
+  Name: '',
+  PkgPath: '',
+  Kind: 'null',
+
+  // for Structs
+  Fields: [],
+
+  // for Classes
+  Methods: [],
+  Extends: [],
+
+  // for Funcs
+  IsVariadic: false,
+  Ins: [],
+  Outs: [],
+  Self: null, // for Methods
+
+  // for Maps
+  Key: null,
+
+  // for Arrays
+  Len: 0,
+
+  // for Array,Chan,Map,Pointer,Slice
+  Elem: null,
+
+  Types: [], // for Unions
+
+  // for exports
+  Visibility: '',
+
+  ...obj,
+});
+
+export const makeField = (obj = {}) => new Field({
+  Name: '',
+  Type: null,
+  Offset: 0,
+  Anonymous: false,
+
+  Optional: false,
+  // for class members (fields and methods)
+  Visibility: '',
+
+  ...obj,
+});
+
+export const makeArgument = (obj = {}) => new Argument({
+  Name: '',
+  Type: null,
+  ...obj,
+});
+
+export const makeSchema = (obj = {}) => new Schema({...obj});
+
+// NOTE(nick): Normalize windows paths for consistency across platforms
+export const normalizePath = (filePath) => {
+  return filePath.replaceAll('\\', '/');
+}
+
+export const toFullyQualifiedName = (it) => {
+  const pkgPath = normalizePath(it.PkgPath);
+
+  const ext = path.extname(pkgPath);
+  const prefix = ext.length > 0 ? pkgPath.slice(0, pkgPath.length - ext.length) : pkgPath;
+  return it.Name.startsWith(prefix) ? it.Name : `${prefix}.${it.Name}`;
+};
+
+export const traverse = (node, fn, ctx = {}) => {
+  fn(node, ctx);
+
+  const parent = node;
+
+  if (typeof node.All === 'function') {
+    node.All().forEach((it, index) => traverse(it, fn, { parent, key: 'All', index }));
+  }
+
+  const traverseArray = (node, key) => {
+    if (Array.isArray(node[key])) {
+      node[key].forEach((it, index) => traverse(it, fn, { parent: node, key, index }));
+    }
+  }
+
+  traverseArray(node, 'Types');
+  traverseArray(node, 'Extends');
+  traverseArray(node, 'Methods');
+  traverseArray(node, 'Fields');
+  traverseArray(node, 'Ins');
+  traverseArray(node, 'Outs');
+
+  if (node.Type) traverse(node.Type, fn, { parent: node, key: 'Type', index: -1 });
+  if (node.Elem) traverse(node.Elem, fn, { parent: node, key: 'Elem', index: -1 });
+  if (node.Key) traverse(node.Key, fn, { parent: node, key: 'Key', index: -1 });
+  if (node.Self) traverse(node.Self, fn, { parent: node, key: 'Self', index: -1 });
+};
+


### PR DESCRIPTION
wip for #5

Goal is to eventually have this live in a separate module, but maybe we can do that without needing to split out all the code (tree shaking?)

Actually the TS library was throwing an error when trying to parse `ast.ts`, so i didn't include / use `ReflectType` in `examples/test.ts`. Should probably fix that

Not yet implemented: `AssignableTo` for non-exact types

Another caveat is while `ReflectType` _does_ get the correct file path, because we're making all of the schemas relative they have a full FQN instead of the relative one. So `.TypeOf(x)` wouldn't work. Not sure exactly what to do about that. The other thing is if you're using any sort of JS bundler (esbuild, etc) then I don't think the trick will work because the code gets evaluated after bundling.